### PR TITLE
Use a graphical terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+rpi-image-gen/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ The image is built using `rpi-image-gen`:
 
 ```sh
 # clone rpi-image-gen repository (or download it)
-git clone https://github.com/raspberrypi/rpi-image-gen.git
+# git clone https://github.com/raspberrypi/rpi-image-gen.git
+wget https://github.com/raspberrypi/rpi-image-gen/archive/refs/heads/master.zip && unzip ./master.zip && rm -f ./master.zip && mv rpi-image-gen-master rpi-image-gen
 cd rpi-image-gen
 # make sure to install its dependencies
 sudo ./install_deps.sh

--- a/provisioner/meta/debian/bookworm/arm64/base-apt.yaml
+++ b/provisioner/meta/debian/bookworm/arm64/base-apt.yaml
@@ -1,0 +1,38 @@
+---
+name: bookworm-arm64
+mmdebstrap:
+  architectures:
+    - arm64
+  mode: auto
+  variant: apt
+  suite: bookworm
+  mirrors:
+    - deb https://deb.debian.org/debian bookworm main contrib non-free non-free-firmware
+    - deb https://deb.debian.org/debian-security bookworm-security main contrib non-free non-free-firmware
+    - deb https://deb.debian.org/debian bookworm-updates main contrib non-free non-free-firmware
+  essential-hooks:
+    - echo tzdata tzdata/Areas select "$IGconf_device_timezone_area"
+        | chroot $1 debconf-set-selections
+    - echo tzdata tzdata/Zones/$IGconf_device_timezone_area select "$IGconf_device_timezone_city"
+        | chroot $1 debconf-set-selections
+    - echo locales locales/locales_to_be_generated multiselect "$IGconf_device_locale1"
+        | chroot $1 debconf-set-selections
+    - echo locales locales/default_environment_locale select "$IGconf_device_locale1"
+        | chroot $1 debconf-set-selections
+    - echo keyboard-configuration keyboard-configuration/variant select "$IGconf_device_keyboard_layout"
+        | chroot $1 debconf-set-selections
+    - echo keyboard-configuration keyboard-configuration/xkb-keymap select "$IGconf_device_keyboard_keymap"
+        | chroot $1 debconf-set-selections
+  aptopts:
+    - APT::Install-Suggests "false"
+    - APT::Install-Recommends "false"
+  dpkgopts:
+    - path-exclude=/usr/share/man/*
+    - path-include=/usr/share/man/man[1-9]/*
+    - path-exclude=/usr/share/locale/*
+    - path-include=/usr/share/locale/locale.alias
+    - path-exclude=/usr/share/doc/*
+    - path-include=/usr/share/doc/*/copyright
+    - path-include=/usr/share/doc/*/changelog.Debian.*
+    - path-exclude=/usr/share/{doc,info,man,omf,help,gnome/help}/*
+    - path-exclude=/usr/share/lintian/*

--- a/provisioner/meta/kiwix/boot-config.yaml
+++ b/provisioner/meta/kiwix/boot-config.yaml
@@ -14,8 +14,6 @@ mmdebstrap:
     - install -m 644 $IGconf_ext_dir/templates/h1/logind-poweroff.conf $1/etc/systemd/logind.conf.d/
     - mkdir -p $1/etc/systemd/system/getty@tty1.service.d/
     - install -m 644 $IGconf_ext_dir/templates/h1/autologin.conf $1/etc/systemd/system/getty@tty1.service.d/
-    - install -m 755 $IGconf_ext_dir/templates/h1/provision-kiosk.sh $1/usr/local/bin/kiosk
-    - install -m 644 $IGconf_ext_dir/templates/h1/bash_profile $1/root/.bash_profile
     - sed -i '/pam_motd/s/^/#/' $1/etc/pam.d/login
 
 

--- a/provisioner/meta/kiwix/dependencies.yaml
+++ b/provisioner/meta/kiwix/dependencies.yaml
@@ -7,10 +7,6 @@ mmdebstrap:
     # Could perform chroot ops here prior to installing non-essential pkgs
   customize-hooks:
     # Could perform ops here after the chroot is set up and packages installed, e.g.
-    # add /etc/default/locale
-    - printf 'LANG=en_US.UTF-8\nLC_ALL=en_US.UTF-8\nLANGUAGE=en_US.UTF-8\n' > $1/etc/default/locale
-    # - sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/g' $1/etc/locale.gen
-    # - chroot $1 locale-gen
     - chroot $1 python3 -m venv /usr/local/lib/provision-env
     # this is where we install our package and auto-pull deps
     - chroot $1 /usr/local/lib/provision-env/bin/pip install https://github.com/offspot/provisioner/archive/refs/heads/main.zip

--- a/provisioner/meta/kiwix/dependencies.yaml
+++ b/provisioner/meta/kiwix/dependencies.yaml
@@ -33,3 +33,4 @@ mmdebstrap:
     - rpi-imager
     - vim
     - libparted-dev
+    - cgroupfs-mount

--- a/provisioner/meta/kiwix/kiosk.yaml
+++ b/provisioner/meta/kiwix/kiosk.yaml
@@ -1,0 +1,17 @@
+---
+name: kiosk
+mmdebstrap:
+  packages:
+    - cage
+    - foot
+    - sox
+    - libsox-fmt-mp3
+    - libid3tag0
+    - fonts-firacode
+  customize-hooks:
+    - install -m 755 $IGconf_ext_dir/templates/h1/provision-kiosk.sh $1/usr/local/bin/kiosk
+    - wget https://dev.kiwix.org/offspot/provision-os/cursor/Transparent_Cursor_Theme-main.tar.gz && tar xf Transparent_Cursor_Theme-main.tar.gz && mv Transparent_Cursor_Theme-main/Transparent $1/usr/share/icons/default && rm -rf ./Transparent_Cursor_Theme-main && rm -r ./Transparent_Cursor_Theme-main.tar.gz
+    - mkdir -p $1/usr/share/fonts/truetype/apple-emoji && wget -O $1/usr/share/fonts/truetype/apple-emoji/AppleColorEmoji.ttf https://dev.kiwix.org/offspot/provision-os/fonts/AppleColorEmoji.ttf
+    - install -m 644 $IGconf_ext_dir/templates/h1/kiosk.service $1/etc/systemd/system/kiosk.service
+    - $BDEBSTRAP_HOOKS/enable-units "$1" kiosk.service
+    - install -m 644 $IGconf_ext_dir/templates/h1/bash_profile $1/root/.bash_profile

--- a/provisioner/meta/kiwix/locales.yaml
+++ b/provisioner/meta/kiwix/locales.yaml
@@ -1,0 +1,8 @@
+---
+name: locales
+mmdebstrap:
+  customize-hooks:
+  - printf 'LANG=en_US.UTF-8\nLC_ALL=en_US.UTF-8\nLANGUAGE=en_US.UTF-8\n' > $1/etc/default/locale
+  - chroot $1 sh -c "apt install -y locales"
+  - sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/g' $1/etc/locale.gen
+  - chroot $1 locale-gen

--- a/provisioner/meta/rpi/debian/bookworm/apt.yaml
+++ b/provisioner/meta/rpi/debian/bookworm/apt.yaml
@@ -1,0 +1,15 @@
+---
+name: debian-bookworm-rpi
+mmdebstrap:
+  mirrors:
+    - deb https://archive.raspberrypi.com/debian bookworm main
+  packages:
+    - raspberrypi-archive-keyring
+  customize-hooks:
+    - test -f $1/usr/share/keyrings/raspberrypi-archive-keyring.gpg || false
+    - mkdir -p $1/etc/apt/sources.list.d
+    - |-
+      cat <<- EOF > $1/etc/apt/sources.list.d/raspberrypi.list
+      deb [signed-by=/usr/share/keyrings/raspberrypi-archive-keyring.gpg] https://archive.raspberrypi.com/debian bookworm main
+      EOF
+    - sed -i '/archive\.raspberrypi\.com/d' $1/etc/apt/sources.list

--- a/provisioner/profile/raspbian-mini
+++ b/provisioner/profile/raspbian-mini
@@ -25,3 +25,5 @@ rpi/user-credentials
 kiwix/locales
 # kiwix provisioner app
 kiwix/dependencies
+# kiwix kiosk mechanism (launches app fullscreen in Wayland terminal)
+kiwix/kiosk

--- a/provisioner/profile/raspbian-mini
+++ b/provisioner/profile/raspbian-mini
@@ -21,5 +21,7 @@ net-misc/openssh-server
 rpi/misc-skel
 # add user with its credentials
 rpi/user-credentials
+# handle locales
+kiwix/locales
 # kiwix provisioner app
 kiwix/dependencies

--- a/provisioner/templates/h1/bash_profile
+++ b/provisioner/templates/h1/bash_profile
@@ -1,5 +1,5 @@
 
-# start kiosk (provisioner app) unless NOKIOSK is set
-if [ -z "$NOKIOSK" ]; then
-  /usr/local/bin/kiosk
+# start kiosk (provisioner app) ONLY if RUNKIOSK is set to 1
+if [ "$RUNKIOSK" = "1" ]; then
+  /usr/local/lib/provision-env/bin/provisioner-script
 fi

--- a/provisioner/templates/h1/cmdline.txt
+++ b/provisioner/templates/h1/cmdline.txt
@@ -1,1 +1,1 @@
-console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes rootwait quiet splash
+console=serial0,115200 console=tty1 root=ROOTDEV rootfstype=ext4 fsck.repair=yes rootwait quiet splash systemd.unified_cgroup_hierarchy=0

--- a/provisioner/templates/h1/config.txt
+++ b/provisioner/templates/h1/config.txt
@@ -54,3 +54,7 @@ dtoverlay=i2c-rtc,pcf2127
 
 # Enable PCI Express Gen.3
 dtparam=pciex1_gen=3
+
+# enable sound via HDMI
+hdmi_group=1
+hdmi_drive=2

--- a/provisioner/templates/h1/kiosk.service
+++ b/provisioner/templates/h1/kiosk.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Kiosk Wayland Session
+After=multi-user.target
+
+[Service]
+User=root
+TTYPath=/dev/tty1
+Environment="XDG_RUNTIME_DIR=/root"
+Environment="RUNKIOSK=1"
+Environment="XCURSOR_PATH=/usr/share/icons"
+Restart=always
+ExecStart=/usr/bin/cage -- foot --fullscreen --login-shell -D /root
+StandardError=journal
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Starts a Wayland session with foot terminal instead of plain agetty.
This is very lightweight yet brings some cool features:

- 24b colors
- unicode support
- emoji

This is implemented as a systemd service
starting at multi-target (so network is ready) on tty1
initiating a password-less login.

A dedicated env tells our shell (bash) to start provisioner-script

Fixes https://github.com/offspot/provisioner/issues/3
Fixes https://github.com/offspot/provision-os/issues/3